### PR TITLE
CMQ-1995 Insert standard fraud prevention header content as second

### DIFF
--- a/resources/public/api/conf/1.0/application.raml
+++ b/resources/public/api/conf/1.0/application.raml
@@ -10,6 +10,8 @@ mediaType: application/json
 documentation:
  - title: Overview
    content: !include docs/overview.md
+ - title: Send fraud prevention data
+   content: !include https://developer.service.hmrc.gov.uk/api-documentation/assets/common/docs/fraud-prevention.md
  - title: Versioning
    content: !include https://developer.service.hmrc.gov.uk/api-documentation/assets/common/docs/versioning.md
  - title: Errors


### PR DESCRIPTION
Sending Fraud Prevention Headers is a legal requirement for MTD APIs but developers sometimes miss this when developing their application. This change inserts the standard Fraud Prevention Header content hosted by Developer Hub as the second section of documentation, immediately below the Overview section.